### PR TITLE
small bug fixes in postprocessor for python3. Also added a job script…

### DIFF
--- a/job-slurm.sh
+++ b/job-slurm.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#SBATCH -D /home/jdherman/pyvin
+#SBATCH -o /home/jdherman/pyvin/job.%j.%N.out
+#SBATCH -e /home/jdherman/pyvin/job.%j.%N.err
+#SBATCH -n 32            # Total number of processors to request (32 cores per node)
+#SBATCH -p med           # Queue name hi/med/lo
+#SBATCH -t 200:00:00        # Run time (hh:mm:ss) - 24 hours
+#SBATCH --mail-user=jdherman@ucdavis.edu              # address for email notification
+#SBATCH --mail-type=ALL                  # email at Begin and End of job
+
+DIR=statewide-82yr-debug
+
+# pyomo solve --solver=glpk --solver-suffix=dual pyvin.py $DIR/data.dat --json --report-timing --stream-solver
+pyomo solve --solver=cbc --solver-suffix=dual --solver-options="threads=32" pyvin.py $DIR/data.dat --json --report-timing --stream-solver
+
+mv results.json $DIR && cd $DIR
+
+python ../postprocessor/postprocess.py
+
+python ../postprocessor/debug_flow_finder.py

--- a/postprocessor/postprocess.py
+++ b/postprocessor/postprocess.py
@@ -6,7 +6,7 @@ def save_dict_as_csv(data, filename):
   time_keys = sorted(data[node_keys[0]].keys()) # add key=int for integer timesteps
 
   header = ['time'] + node_keys
-  writer = csv.writer(open(filename, 'wb'))
+  writer = csv.writer(open(filename, 'w'))
   writer.writerow(header)
   
   for t in time_keys:
@@ -33,7 +33,7 @@ def dict_insert(D, k1, k2, v, collision_rule):
     if collision_rule == 'sum':
       D[k1][k2] += v
     elif collision_rule == 'max':
-      if v is not None and v > D[k1][k2]:
+      if v is not None and (D[k1][k2] is None or v > D[k1][k2]):
         D[k1][k2] = v
 
 # start with four empty dicts -- this is


### PR DESCRIPTION
… for the HPC1 cluster

Mustafa, these are two small changes in the postprocessor which were causing errors in Python 3. And an example job script. Not urgent, I know you're on vacation :)

As you can see in the job script I've been experimenting with the CBC solver, which is also free. It has a parallel option because it's not a simplex method. So far it has been faster on the 1-year example, but only about 2x faster. I'm trying it right now on HPC1 using the full 82-year example, will report back.
