### PR TITLE
Preprocess network

### DIFF
--- a/preprocessor/networkcheck.py
+++ b/preprocessor/networkcheck.py
@@ -25,12 +25,19 @@ nrows_n = len(nodes) # # of rows in nodes
 
 # loop over links
 for l in links[1:]:
+  lb = float(l[5])
+  ub = float(l[6])
   num_in[l[1]] += 1
-  lb_in[l[1]] += float(l[5])
-  ub_in[l[1]] += float(l[6])
+  lb_in[l[1]] += lb
+  ub_in[l[1]] += ub
   num_out[l[0]] += 1
-  lb_out[l[0]] += float(l[5])
-  ub_out[l[0]] += float(l[6])
+  lb_out[l[0]] += lb
+  ub_out[l[0]] += ub
+
+  if lb > ub:
+    print('lb > ub for link %s' % (l[0]+'-'+l[1]))
+
+
 
 for n in nodes:
   if num_in[n[0]] == 0:


### PR DESCRIPTION
@msdogan 

This updates `networkcheck.py` so that it should now find any of the following problems:
- Nodes with no inflow links (or no outflow links)
- Nodes where mass balance constraints are impossible to satisfy (if either `ub_in < lb_out` or `lb_in < ub_out`)
- Links where `lb > ub`

It's using dictionaries instead of lists, which makes it a little cleaner but it means the CSV writing doesn't work. We can always redirect the console output into a file if we need to save it for some reason.
