### PR TITLE
small chnage in mass balance dual

### DIFF
--- a/calvin/postprocessor.py
+++ b/calvin/postprocessor.py
@@ -111,7 +111,7 @@ def postprocess(df, model, resultdir=None, annual=False):
   for node in nodes:
     if '.' in node:
       n3,t3 = node.split('.')
-      d3 = model.dual[model.flow[s]] if s in model.flow else 0.0
+      d3 = model.dual[model.flow[node]] if node in model.flow else 0.0
       dict_insert(D_node, n3, t3, d3)
 
   # write the output files


### PR DESCRIPTION
I believe it should be flow[node] instead of flow[s].

’s’ is outside the “for” loop (in previous “for” loop). This configuration would always return zeros for mass balance constraint node dual values.