### PR TITLE
Update postprocess.py

### DIFF
--- a/calvin/postprocessor.py
+++ b/calvin/postprocessor.py
@@ -146,7 +146,13 @@ def postprocess(df, model, resultdir=None, annual=False):
 
   # write the output files
   import datetime, os
-
+  
+  # this if statement added on 7/23/2020 by MSD. 'mode' variable was referenced before assignment.
+  if annual:
+      mode = 'a'
+  else:
+      mode = 'w'
+      
   if not resultdir:
     if annual:
       raise RuntimeError('resultdir must be specified for annual run')


### PR DESCRIPTION
I was getting following error because 'mode' variable was referenced before assignment when there was already a directory to save result files.
"'
  File "C:\Users\PC\Documents\GitHub\calvin\calvin\postprocessor.py", line 166, in postprocess
    save_dict_as_csv(data, resultdir + '/' + name + '.csv', mode)

UnboundLocalError: local variable 'mode' referenced before assignment
"'
@jdherman could you please review and merge or revise as needed? Thanks!