### PR TITLE
update calvin.py

### DIFF
--- a/calvin/calvin.py
+++ b/calvin/calvin.py
@@ -173,7 +173,7 @@ class CALVIN():
       links.upper_bound = maxub
       links['link'] = links.i.map(str) + '_' + links.j.map(str) + '_' + links.k.map(str)
       links.set_index('link', inplace=True)
-      self.df = self.df._append(links.drop_duplicates())
+      self.df = pd.concat([df,links.drop_duplicates()])
 
 
   def fix_hydropower_lbs(self):


### PR DESCRIPTION
"._append" was deprecated. Now calvin.py uses pd.concat to merge two dataframes instead.